### PR TITLE
Update BD (events table)

### DIFF
--- a/database/migrations/2025_03_14_093915_remove_position_from_players_table.php
+++ b/database/migrations/2025_03_14_093915_remove_position_from_players_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('players', function (Blueprint $table) {
+            $table->dropColumn('position');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('players', function (Blueprint $table) {
+            $table->string('position', 10);
+        });
+    }
+};

--- a/database/migrations/2025_03_14_094324_create_events_table.php
+++ b/database/migrations/2025_03_14_094324_create_events_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->string('name',50);
+            $table->foreignId('player_id')->constrained('players')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/migrations/2025_03_14_095150_add_event_id_to_stats_table.php
+++ b/database/migrations/2025_03_14_095150_add_event_id_to_stats_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stats', function (Blueprint $table) {
+            $table->foreignId('event_id')->after('action_id')->constrained('events')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stats', function (Blueprint $table) {
+            $table->dropForeign(['event_id']);
+            $table->dropColumn('event_id');
+        });
+    }
+};


### PR DESCRIPTION
feat: Atualização da estrutura do banco de dados

- Removida a coluna 'position' da tabela 'players'.
- Criada a tabela 'events' com 'id', 'name', 'player_id' (FK para 'players') e timestamps.
- Adicionada a coluna 'event_id' à tabela 'stats', posicionada após 'action_id', como FK para 'events'.